### PR TITLE
Fixes sublime.sh missing directory issue

### DIFF
--- a/sublime.sh
+++ b/sublime.sh
@@ -1,3 +1,7 @@
+# Create Sublime Text directories as they don't exist until Sublime is opened
+mkdir -p ~/Library/Application\ Support/Sublime\ Text\ 3/Installed\ Packages/Package\
+mkdir -p ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/User/
+
 # Install Package Control
 curl "https://packagecontrol.io/Package%20Control.sublime-package" > settings/Package\ Control.sublime-package
 cp -r settings/Package\ Control.sublime-package ~/Library/Application\ Support/Sublime\ Text\ 3/Installed\ Packages/Package\ Control.sublime-package
@@ -11,5 +15,5 @@ cp -r settings/Default\ \(OSX\).sublime-keymap ~/Library/Application\ Support/Su
 cp -r settings/Python-2.sublime-build ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/User/
 cp -r settings/Python-3.sublime-build ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/User/
 
-# Creat symlink to subl command
+# Create symlink to subl command
 ln -s /Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl /usr/local/bin/subl


### PR DESCRIPTION
Sublime Text creates its directories on the first launch (just found out about this last week when trying to show someone how to set up Sublime) so this just creates them in the Script to ensure the files get copied :)