### PR TITLE
Update .bash_prompt

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -60,7 +60,7 @@ prompt_git() {
 }
 
 if tput setaf 1 &> /dev/null; then
-	tput sgr0; # reset colors
+	tput sgr0 &> /dev/null; # reset colors
 	bold=$(tput bold);
 	reset=$(tput sgr0);
 	# Solarized colors, taken from http://git.io/solarized-colors.


### PR DESCRIPTION
redirect output from the `tput sgr0` command to /dev/null, otherwise this interferes with scp/sftp displays in MobaXterm