### PR TITLE
Fix Bluetooth menu bar setting for current macOS

### DIFF
--- a/macOS.sh
+++ b/macOS.sh
@@ -3,6 +3,8 @@
 # macOS system settings.
 # Safe to re-run: settings are only written (and the affected system UI
 # only restarted) when the current value differs.
+# Some settings rely on undocumented "magic" values that can change between
+# macOS releases — periodically check that each still does what it says.
 ############################
 
 set -euo pipefail
@@ -40,8 +42,9 @@ else
 fi
 
 # Add Bluetooth to Menu Bar for battery percentages
-if [[ "$(defaults read com.apple.controlcenter "NSStatusItem Visible Bluetooth" 2>/dev/null || true)" != "1" ]]; then
-    defaults write com.apple.controlcenter "NSStatusItem Visible Bluetooth" -bool true
+# (stored per-host by Control Center; 2 = show in menu bar)
+if [[ "$(defaults -currentHost read com.apple.controlcenter Bluetooth 2>/dev/null || true)" != "2" ]]; then
+    defaults -currentHost write com.apple.controlcenter Bluetooth -int 2
     killall ControlCenter &>/dev/null || true
     info "Added Bluetooth to the menu bar."
 else


### PR DESCRIPTION
Follow-up to #16, found while comparing re-run output across two machines: the Bluetooth step's \`defaults\` key is a previous-generation setting that current Control Center ignores. The real setting is a per-host integer (\`2\` = show in menu bar). One machine was rewriting the dead key on every run (never idempotent-skipping); the other reported "already set" while the icon was actually hidden.

Verified live on two machines in both directions (writing the hide-value removed a visible icon; writing \`2\` surfaced it on a machine where it had never appeared).

Also adds a header note that some settings in this script rely on undocumented values worth re-checking periodically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)